### PR TITLE
Add dark mode toggle

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,6 +6,7 @@
     {% include meta.html %}
 
     <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/assets/style.css" />
+    <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/assets/dark-mode.css" />
     <link rel="alternate" type="application/rss+xml" title="{{ site.name }} - {{ site.description }}" href="{{ site.baseurl }}/feed.xml" />
     <link rel="canonical" href="{{ site.url }}{{ page.url }}" />
 
@@ -13,6 +14,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="{{ site.baseurl }}/images/favicon-32x32.png">
     {% include analytics_head.html %}
     {% include scripts.html%}
+    <script src="{{ site.baseurl }}/assets/theme-toggle.js" defer></script>
   </head>
 
   <body>
@@ -33,6 +35,7 @@
               <a href="{{ site.baseurl }}/search">Search</a>
               <a href="{{ site.baseurl }}/about">About</a>
               <a href="{{ site.baseurl }}/gallery">Gallery</a>
+              <button id="theme-toggle" aria-label="Toggle dark mode">🌙</button>
             </nav>
           </header>
         </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,6 +5,16 @@
     {% seo title=false %}
     {% include meta.html %}
 
+    <script>
+      (function() {
+        var saved = localStorage.getItem('theme');
+        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        if (saved === 'dark' || (saved === null && prefersDark)) {
+          document.documentElement.classList.add('dark-mode');
+        }
+      })();
+    </script>
+
     <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/assets/style.css" />
     <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/assets/dark-mode.css" />
     <link rel="alternate" type="application/rss+xml" title="{{ site.name }} - {{ site.description }}" href="{{ site.baseurl }}/feed.xml" />

--- a/assets/dark-mode.css
+++ b/assets/dark-mode.css
@@ -33,6 +33,18 @@ body.dark-mode nav #theme-toggle {
   color: var(--dark-text);
 }
 
+body.dark-mode .pagination a,
+body.dark-mode .pagination span {
+  background-color: #333;
+  border-color: #555;
+  color: var(--dark-text);
+}
+
+body.dark-mode .pagination a:hover {
+  background-color: #444;
+  color: var(--dark-text);
+}
+
 body.dark-mode .wrapper-footer {
   background-color: #1e1e1e;
 }

--- a/assets/dark-mode.css
+++ b/assets/dark-mode.css
@@ -33,6 +33,28 @@ body.dark-mode nav #theme-toggle {
   color: var(--dark-text);
 }
 
+body.dark-mode .wrapper-footer {
+  background-color: #1e1e1e;
+}
+
+body.dark-mode footer {
+  color: var(--dark-text);
+}
+
+body.dark-mode .post-tags a {
+  background-color: #333;
+  color: var(--dark-text);
+}
+
+body.dark-mode h1,
+body.dark-mode h2,
+body.dark-mode h3,
+body.dark-mode h4,
+body.dark-mode h5,
+body.dark-mode h6 {
+  color: var(--dark-text);
+}
+
 body.dark-mode nav a:hover {
   color: var(--dark-link);
 }

--- a/assets/dark-mode.css
+++ b/assets/dark-mode.css
@@ -13,61 +13,61 @@ body {
   transition: background-color 0.3s, color 0.3s;
 }
 
-body.dark-mode {
+.dark-mode body {
   background: var(--dark-bg);
   color: var(--dark-text);
 }
 
-body.dark-mode a {
+.dark-mode a {
   color: var(--dark-link);
 }
 
-body.dark-mode .masthead {
+.dark-mode .masthead {
   border-bottom-color: #333;
 }
 
-body.dark-mode .site-name,
-body.dark-mode .site-description,
-body.dark-mode nav a,
-body.dark-mode nav #theme-toggle {
+.dark-mode .site-name,
+.dark-mode .site-description,
+.dark-mode nav a,
+.dark-mode nav #theme-toggle {
   color: var(--dark-text);
 }
 
-body.dark-mode .pagination a,
-body.dark-mode .pagination span {
+.dark-mode .pagination a,
+.dark-mode .pagination span {
   background-color: #333;
   border-color: #555;
   color: var(--dark-text);
 }
 
-body.dark-mode .pagination a:hover {
+.dark-mode .pagination a:hover {
   background-color: #444;
   color: var(--dark-text);
 }
 
-body.dark-mode .wrapper-footer {
+.dark-mode .wrapper-footer {
   background-color: #1e1e1e;
 }
 
-body.dark-mode footer {
+.dark-mode footer {
   color: var(--dark-text);
 }
 
-body.dark-mode .post-tags a {
+.dark-mode .post-tags a {
   background-color: #333;
   color: var(--dark-text);
 }
 
-body.dark-mode h1,
-body.dark-mode h2,
-body.dark-mode h3,
-body.dark-mode h4,
-body.dark-mode h5,
-body.dark-mode h6 {
+.dark-mode h1,
+.dark-mode h2,
+.dark-mode h3,
+.dark-mode h4,
+.dark-mode h5,
+.dark-mode h6 {
   color: var(--dark-text);
 }
 
-body.dark-mode nav a:hover {
+.dark-mode nav a:hover {
   color: var(--dark-link);
 }
 
@@ -87,6 +87,6 @@ nav #theme-toggle {
   }
 }
 
-body.dark-mode nav #theme-toggle {
+.dark-mode nav #theme-toggle {
   color: var(--dark-text);
 }

--- a/assets/dark-mode.css
+++ b/assets/dark-mode.css
@@ -1,0 +1,58 @@
+:root {
+  --light-bg: #fff;
+  --light-text: #404040;
+  --light-link: #4183C4;
+  --dark-bg: #121212;
+  --dark-text: #e0e0e0;
+  --dark-link: #8ab4f8;
+}
+
+body {
+  background: var(--light-bg);
+  color: var(--light-text);
+  transition: background-color 0.3s, color 0.3s;
+}
+
+body.dark-mode {
+  background: var(--dark-bg);
+  color: var(--dark-text);
+}
+
+body.dark-mode a {
+  color: var(--dark-link);
+}
+
+body.dark-mode .masthead {
+  border-bottom-color: #333;
+}
+
+body.dark-mode .site-name,
+body.dark-mode .site-description,
+body.dark-mode nav a,
+body.dark-mode nav #theme-toggle {
+  color: var(--dark-text);
+}
+
+body.dark-mode nav a:hover {
+  color: var(--dark-link);
+}
+
+nav #theme-toggle {
+  margin-left: 20px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 18px;
+  color: #333;
+}
+
+@media screen and (max-width: 640px) {
+  nav #theme-toggle {
+    margin: 0 10px;
+    color: #4183C4;
+  }
+}
+
+body.dark-mode nav #theme-toggle {
+  color: var(--dark-text);
+}

--- a/assets/theme-toggle.js
+++ b/assets/theme-toggle.js
@@ -1,16 +1,12 @@
 document.addEventListener('DOMContentLoaded', function() {
   var toggle = document.getElementById('theme-toggle');
   if (!toggle) return;
-  var saved = localStorage.getItem('theme');
-  var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-  if (saved === 'dark' || (saved === null && prefersDark)) {
-    document.body.classList.add('dark-mode');
-    toggle.textContent = '☀️';
-  }
+  var isDark = document.documentElement.classList.contains('dark-mode');
+  toggle.textContent = isDark ? '☀️' : '🌙';
   toggle.addEventListener('click', function() {
-    document.body.classList.toggle('dark-mode');
-    var isDark = document.body.classList.contains('dark-mode');
-    toggle.textContent = isDark ? '☀️' : '🌙';
-    localStorage.setItem('theme', isDark ? 'dark' : 'light');
+    document.documentElement.classList.toggle('dark-mode');
+    var dark = document.documentElement.classList.contains('dark-mode');
+    toggle.textContent = dark ? '☀️' : '🌙';
+    localStorage.setItem('theme', dark ? 'dark' : 'light');
   });
 });

--- a/assets/theme-toggle.js
+++ b/assets/theme-toggle.js
@@ -1,0 +1,16 @@
+document.addEventListener('DOMContentLoaded', function() {
+  var toggle = document.getElementById('theme-toggle');
+  if (!toggle) return;
+  var saved = localStorage.getItem('theme');
+  var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  if (saved === 'dark' || (saved === null && prefersDark)) {
+    document.body.classList.add('dark-mode');
+    toggle.textContent = '☀️';
+  }
+  toggle.addEventListener('click', function() {
+    document.body.classList.toggle('dark-mode');
+    var isDark = document.body.classList.contains('dark-mode');
+    toggle.textContent = isDark ? '☀️' : '🌙';
+    localStorage.setItem('theme', isDark ? 'dark' : 'light');
+  });
+});


### PR DESCRIPTION
## Summary
- Add dark mode stylesheet and theme switcher button with sun/moon icon
- Persist user theme preference using localStorage

## Testing
- `bundle install` (fails: Gem::Net::HTTPClientException 403)
- `bundle exec jekyll build` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a00592d1a483218453f47811c6aecc
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds dark mode toggle with persistent user preference and updates styles and scripts for theme management.
> 
>   - **Dark Mode Feature**:
>     - Adds a dark mode toggle button with sun/moon icon in `_layouts/default.html`.
>     - Persists user theme preference using `localStorage`.
>     - Automatically applies dark mode based on user preference or system settings.
>   - **Styles**:
>     - Introduces `assets/dark-mode.css` for dark mode styling.
>     - Updates styles for body, links, headers, and navigation in dark mode.
>   - **JavaScript**:
>     - Adds `assets/theme-toggle.js` to handle theme toggling and update button icon.
>     - Listens for `DOMContentLoaded` to initialize theme based on `localStorage`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RTnhN%2FRTnhN.github.io&utm_source=github&utm_medium=referral)<sup> for 86a9264176dce9f795f8cbc96574518eb0b046ed. You can [customize](https://app.ellipsis.dev/RTnhN/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->